### PR TITLE
C++ opt flags, benches, Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin
 obj
 chaosTesting
 docs/drawio
+/benchmarks/node_modules
+/benchmarks/package-lock.json

--- a/README.md
+++ b/README.md
@@ -88,21 +88,22 @@ make --version
 ```
 ![Make version](docs/documentationImages/makeVersion.png "Make version")
 
-The command to build Papy is the following once you are in the project root directory. 
+The command to build Papy in release mode is the following once you are in the project root directory. 
 ```bash
-make build
+make rel
 ```
-![Make build](docs/documentationImages/makeBuild.png "Make build")
+Note: by default, it uses dynamic linking. For distribution you probably want static linking, add `STATIC_FLAG=-static` to your make command (e.g. `make rel STATIC_FLAG=-static`). Changing this (switching to dynamic from static / vice versa) requires `make clean` (*actually, it only needs re-lininking, which you can also enforce by deleting executable*)
 
+![Make build](docs/documentationImages/makeBuild.png "Make build")
 ### Initial Setup
 Now we got Papy up built and ready for you! Lets get our hands on it now. After the build the Papy Binary/executable will be in the `bin` directory.
 
-Navigate to the `Papy/bin` directory:
+Navigate to the `Papy/bin/rel` directory:
 ```bash
-cd bin
+cd bin/rel
 ```
 
-Papy will be in the `bin` directory. Run the Papy help command to get a sense of what flags you can make use of and to verify that papy was built successfully.
+Papy will be in the `bin/rel` directory (or in `bin/dev` if build in development mode (`make dev`). Run the Papy help command to get a sense of what flags you can make use of and to verify that papy was built successfully.
 ```bash
 ./papy --help
 ```

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,13 @@
+to run benchmarks, invoke corresponding benchmark script from porject_root/benchmarks/
+e.g.
+```bash
+your/path/to/Papy> cd benchmarks
+your/path/to/Papy/benchmarks$> sudo benchmark_linux.sh -threads 1 -runs 4 -count 1000
+```
+On Linux, nginx is used as a http server\
+On Windows, you need to `npm install` in `benchmarks/` first (express is used)
+
+Why is this an entire script running several processes and not just bench.cpp*?\
+The reason is that real world is a bit complicated and such benchmark is closer to what you would observe in real world\
+Windows benchmark exist for fun, use Linux if you want real benchmarking\
+*you can actually do the same realistic benchmark in cpp, but result will not be any different - you will still be io bound

--- a/benchmarks/benchmark_linux.sh
+++ b/benchmarks/benchmark_linux.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+# Default values
+THREADS=1
+RUNS=5
+COUNT=10000
+
+# Function to parse named arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -threads)
+            THREADS="$2"
+            shift 2
+            ;;
+        -runs)
+            RUNS="$2"
+            shift 2
+            ;;
+        -count)
+            COUNT="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+TARGET="http://127.0.0.1:5000"
+ENDPOINT="/benchmark"
+NGINX_CONF="/tmp/nginx_papy.conf"
+NGINX_PID="/tmp/nginx_papy.pid"
+
+# Function to create a temporary Nginx configuration
+create_nginx_config() {
+    cat <<EOL > $NGINX_CONF
+events {}
+
+http {
+    server {
+        listen 5000;
+        server_name localhost;
+
+        location / {
+            return 200 "hello flask";
+            add_header Content-Type text/plain;
+        }
+
+        location /benchmark {
+            return 200 "benching";
+            add_header Content-Type text/plain;
+        }
+    }
+}
+EOL
+}
+
+start_nginx() {
+    echo "starting nginx..."
+    sudo nginx -c $NGINX_CONF -p /tmp -g "pid $NGINX_PID;"
+    sleep 1  # give nginx a moment
+}
+
+stop_nginx() {
+    if [[ -f $NGINX_PID ]]; then
+        echo "stopping nginx..."
+        sudo kill "$(cat $NGINX_PID)" 2>/dev/null
+        rm -f $NGINX_PID
+    fi
+}
+
+# return when nginx is ready to use
+wait_for_nginx() {
+    for i in {1..10}; do
+        if curl -s --head --request GET "$TARGET$ENDPOINT" | grep "200 OK" > /dev/null; then
+            echo "nginx is up!"
+            return 0
+        fi
+        echo "waiting for nginx to start..."
+        sleep 1
+    done
+    echo "ERROR: nginx did not start properly"
+    exit 1
+}
+
+# run & measure Papy (number will be different from what Papy shows due to overhead of starting things. 
+# You can decrease relative impact of such overhead by increasing count)
+benchmark() {
+    local papy_path=$1
+    local total_time=0
+
+    echo "Benchmarking $papy_path for $RUNS runs (Threads: $THREADS, Count: $COUNT)..."
+
+    for ((i = 1; i <= RUNS; i++)); do
+        START=$(date +%s%N)
+        ./$papy_path --threads $THREADS --target "$TARGET" --endpoint "$ENDPOINT" --count $COUNT > /dev/null 2>&1
+        END=$(date +%s%N)
+        TIME=$(( (END - START) / 1000000 ))  # Convert ns to ms
+        total_time=$((total_time + TIME))
+        echo "Run #$i: $TIME ms"
+    done
+
+    echo "Total time for $papy_path: $total_time ms"
+    echo "=================================="
+}
+
+# create and run temp nginx config
+create_nginx_config
+start_nginx
+wait_for_nginx
+
+echo "Starting benchmark..."
+benchmark "../bin/dev/papy"
+benchmark "../bin/rel/papy"
+
+# stop nginx after benchmarking
+stop_nginx
+rm -f $NGINX_CONF

--- a/benchmarks/benchmark_windows.bat
+++ b/benchmarks/benchmark_windows.bat
@@ -1,0 +1,136 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Change to script directory
+pushd "%~dp0"
+
+:: Default values
+set THREADS=1
+set RUNS=4
+set COUNT=100
+
+:: Parse command-line arguments
+:parse_args
+if "%~1"=="" goto run_benchmark
+if "%~1"=="-threads" (set THREADS=%~2 & shift & shift & goto parse_args)
+if "%~1"=="-runs" (set RUNS=%~2 & shift & shift & goto parse_args)
+if "%~1"=="-count" (set COUNT=%~2 & shift & shift & goto parse_args)
+echo Unknown option: %~1
+popd
+exit /b 1
+
+:run_benchmark
+:: Kill any existing Node servers first
+taskkill /IM node.exe /F > nul 2>&1
+
+:: Install dependencies
+echo Installing Node.js dependencies...
+call :install_dependencies
+if errorlevel 1 (
+    echo Failed to install dependencies
+    popd
+    exit /b 1
+)
+
+echo Starting Node.js server...
+start "PapyServer" /B node nodejs_server.js
+call :get_node_pid
+
+echo Checking server status...
+call :wait_for_server
+if errorlevel 1 (
+    echo Failed to start server
+    popd
+    exit /b 1
+)
+
+:: Function to benchmark Papy
+call :benchmark "..\bin\dev\papy.exe"
+call :benchmark "..\bin\rel\papy.exe"
+
+:: Cleanup
+echo Stopping Node.js server...
+taskkill /PID !NODE_PID! /F > nul 2>&1
+popd
+exit /b
+
+:install_dependencies
+:: Check if node_modules exists
+if exist "node_modules" (
+    echo node_modules already exists, skipping install
+    exit /b 0
+)
+
+:: Run npm install
+echo Running npm install...
+npm install --silent
+if errorlevel 1 (
+    echo npm install failed
+    exit /b 1
+)
+exit /b 0
+
+:benchmark
+set PAPY_PATH=%~1
+set TOTAL_TIME=0
+echo Benchmarking %PAPY_PATH% for %RUNS% runs (Threads: %THREADS%, Count: %COUNT%)...
+
+for /L %%i in (1,1,%RUNS%) do (
+    set "startTime=!time!"
+    %PAPY_PATH% --threads %THREADS% --target "http://127.0.0.1:5000" --endpoint "/benchmark" --count %COUNT% >nul 2>&1
+    set "stopTime=!time!"
+    
+    call :time_diff TIME_TAKEN startTime stopTime
+    set /A TOTAL_TIME+=TIME_TAKEN
+    echo Run #%%i: !TIME_TAKEN! ms
+)
+
+echo Total time for %PAPY_PATH%: %TOTAL_TIME% ms
+echo ==================================
+exit /b
+
+:get_node_pid
+set NODE_PID=
+for /f "tokens=5" %%a in (
+    'netstat -ano ^| findstr ":5000 " ^| findstr "LISTENING"'
+) do set NODE_PID=%%a
+exit /b
+
+:wait_for_server
+echo Waiting for server to start...
+set /a attempts=0
+:retry
+powershell -Command "$response = try { Invoke-WebRequest -Uri http://127.0.0.1:5000/benchmark -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop } catch {}; if ($response.StatusCode -eq 200) { exit 0 } else { exit 1 }"
+if %errorlevel% equ 0 (
+    echo Server is ready!
+    exit /b 0
+)
+set /a attempts+=1
+if !attempts! geq 10 (
+    echo Failed to start server after 10 attempts
+    exit /b 1
+)
+timeout /t 1 > nul
+goto retry
+
+:time_diff
+setlocal
+call :time_to_ms time1 "%~2"
+call :time_to_ms time2 "%~3"
+set /a diff=time2-time1
+(
+  ENDLOCAL
+  set "%~1=%diff%"
+  goto :eof
+)
+
+:time_to_ms
+SETLOCAL EnableDelayedExpansion
+FOR /F "tokens=1,2,3,4 delims=:,.^ " %%a IN ("!%~2!") DO (
+  set /a "ms=(((30%%a%%100)*60+7%%b)*60+3%%c-42300)*1000+(1%%d0 %% 1000)"
+)
+(
+  ENDLOCAL
+  set %~1=%ms%
+  goto :eof
+)

--- a/benchmarks/nodejs_server.js
+++ b/benchmarks/nodejs_server.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const app = express();
+
+app.get('/', (req, res) => {
+    res.set('Content-Type', 'text/plain');
+    res.send('hello node');
+});
+
+app.get('/benchmark', (req, res) => {
+    res.set('Content-Type', 'text/plain');
+    res.send('benching');
+});
+
+app.listen(5000, () => console.log('Server running on port 5000'));

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "express": "^4.21.2"
+  }
+}

--- a/makefile
+++ b/makefile
@@ -1,52 +1,81 @@
 # Directories
 SRC_DIR = src
+
 OBJ_DIR = obj
+OBJ_DIR_REL = $(OBJ_DIR)/rel
+OBJ_DIR_DEV = $(OBJ_DIR)/dev
+
 BIN_DIR = bin
+BIN_DIR_REL = $(BIN_DIR)/rel
+BIN_DIR_DEV = $(BIN_DIR)/dev
+
 OPENSSL_DIR = $(SRC_DIR)/dependencies/openssl/include  # Local OpenSSL directory
 ZLIB_DIR = $(SRC_DIR)/dependencies/gzip/include
 
 # Compiler and flags
 CXX = g++
-CXXFLAGS_COMMON = -I$(OPENSSL_DIR) -I$(ZLIB_DIR) -MMD -MP   # Include dependency tracking
-ifeq ($(shell uname), Darwin)
-	CXXFLAGS = -std=c++2b $(CXXFLAGS_COMMON)  # macOS-specific flags
-else
-	CXXFLAGS = -std=c++23 $(CXXFLAGS_COMMON)  # Default flags
+# Link Time Optimization + high level of optimization + strip
+CXX_REL_OPT_FLAGS = -flto -O3 -s $(STATIC_FLAG) # set STATIC_FLAG=-static in make invocation from terminal to get static linking 
+CXXFLAGS_COMMON = -I$(OPENSSL_DIR) -I$(ZLIB_DIR) -MMD -MP # Include dependency tracking
+ifeq ($(shell uname), Darwin) # macOS-specific flags
+	CXXFLAGS_REL = $(CXX_REL_OPT_FLAGS) -std=c++2b $(CXXFLAGS_COMMON)
+	CXXFLAGS_DEV = -std=c++2b $(CXXFLAGS_COMMON)
+else # Default flags
+	CXXFLAGS_REL = $(CXX_REL_OPT_FLAGS) -std=c++23 $(CXXFLAGS_COMMON)
+	CXXFLAGS_DEV = -std=c++23 $(CXXFLAGS_COMMON)
 endif
 
-# Linker flags
-LDFLAGS = -L$(OPENSSL_DIR) -L$(ZLIB_DIR) -lssl -lcrypto -lz # Link local OpenSSL libraries
+# Linker flags. Actually, just g++ flags
+# Links with local OpenSSL libraries and some more on windows (TODO: other platforms)
+LDFLAGS_DEV = -L$(OPENSSL_DIR) -L$(ZLIB_DIR) -lssl -lcrypto -lz 
+# On windows these libs are needed (otherwise you end up using funs you do not link with)
+ifeq ($(OS),Windows_NT)
+	LDFLAGS_DEV += -lws2_32 -lcrypt32
+endif
+LDFLAGS_REL = $(CXX_REL_OPT_FLAGS) $(LDFLAGS_DEV)
 
 # Source files and object files
 SRC_FILES = $(wildcard $(SRC_DIR)/*.cpp)
-OBJ_FILES = $(SRC_FILES:$(SRC_DIR)/%.cpp=$(OBJ_DIR)/%.o)
+# object files for rel/dev are stored separately to allow independent incremental building of both
+OBJ_FILES_REL = $(SRC_FILES:$(SRC_DIR)/%.cpp=$(OBJ_DIR_REL)/%.o)
+OBJ_FILES_DEV = $(SRC_FILES:$(SRC_DIR)/%.cpp=$(OBJ_DIR_DEV)/%.o)
 
 # Track build dependencies
 DEP_FILES = $(SRC_FILES:$(SRC_DIR)/%.cpp=$(OBJ_DIR)/%.d)
 
 # Output executable
-TARGET = $(BIN_DIR)/papy
+TARGET_REL = $(BIN_DIR_REL)/papy
+TARGET_DEV = $(BIN_DIR_DEV)/papy
 
 # Default target to build
-all: directories $(TARGET)
+all: rel
+
+dev: directories $(TARGET_DEV)
+rel: directories $(TARGET_REL)
 
 # Create required directories if they don't exist
 directories:
-	@mkdir -p $(OBJ_DIR) $(BIN_DIR)
+	@mkdir -p $(OBJ_DIR)/dev $(OBJ_DIR)/rel
+	@mkdir -p $(BIN_DIR)/dev $(BIN_DIR)/rel
 
 # Link object files to create the executable
-$(TARGET): $(OBJ_FILES)
-	$(CXX) $(OBJ_FILES) -o $@ $(LDFLAGS)
+$(TARGET_REL): $(OBJ_FILES_REL)
+	$(CXX) $(OBJ_FILES_REL) -o $@ $(LDFLAGS_REL)
+$(TARGET_DEV): $(OBJ_FILES_DEV)
+	$(CXX) $(OBJ_FILES_DEV) -o $@ $(LDFLAGS_DEV)
 
 # Rule to compile .cpp to .o
-$(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp | directories
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+$(OBJ_DIR_REL)/%.o: $(SRC_DIR)/%.cpp | directories
+	$(CXX) $(CXXFLAGS_REL) -c $< -o $@
+$(OBJ_DIR_DEV)/%.o: $(SRC_DIR)/%.cpp | directories
+	$(CXX) $(CXXFLAGS_DEV) -c $< -o $@
 
 -include $(DEP_FILES)
 
-# Clean up object files and executable
+# Clean up object files and executable (dep files too for safity, they take nothing to create but can break build if something is messed up)
 clean:
-	rm -rf $(OBJ_DIR)/*.o $(TARGET)
+	rm -rf $(OBJ_DIR)/*
+	rm -rf $(BIN_DIR)/*
 
 # Rebuild the project
 rebuild: clean all


### PR DESCRIPTION
Hey there!

I ended up tinkering with Papy and noticed that you were missing optimization flags entirely (though it turned out not as bad as one might expect). I guess that’s because you come from a JIT-compiled language where this isn’t really a thing. The C/C++ build model is a bit messy (but props for using makefiles - great choice!). By default, none of the major compilers (GCC, Clang, MSVC) apply optimizations, which means your code runs unoptimized unless you explicitly enable them

Optimizations do a lot - removing unused code, inlining functions, simplifying math, unrolling loops, applying SIMD, replacing assignments with memcpy, and much, much more (pr adds "-O3" to g++ flags to enable them). There is also Link-Time Optimization (LTO) to provide the compiler with more information across object files, which is crucial for both performance and binary size (pr adds "-flto" to g++ flags for that). In hot loops, optimizations can easily make a 10x difference

That said, looking at the benchmarks, the difference between optimized and unoptimized builds is only about 30% in single-threaded mode, which makes sense since Papy is mostly I/O. So while it didn’t turn out to be a major issue here, missing "free" optimizations isn’t something you want in your projects

Summary of changes:
 - benchmarking scripts for Linux and Windows
 - separate rel/dev object files for independent incremental compilation
 - fix for missing libraries in linker arguments for Windows
 - changes to README to reflect makefile changes (static vs dynamic linking clarification is needed imo)

I'd suggest removing Google (`./papy --threads 4 --target "https://www.google.com"`) from the README - it’s probably not great to have something that looks like a DDoS example in there
`make rebuild` seems useless unless you’re changing compiler flags. For code changes, make already rebuilds what’s needed based on timestamps
`-j$(nproc)` only works on Linux, maybe change it to something like `-j8`
The "Command to run build and execution with a test" section in the README seems out-of-place, but i might be missing something
Compilation times are also surprisingly large. I might look into it later, my guess is that its a lot of json/std template instantiated everywhere, and it can probably be improved by using precompiled headers or (and) explicit template instantiation (promise that code for templates is generated separately in a file that does not change often and thus rebuilds less often, and avoid generating duplicated code in every file where template is used)