### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ make --version
 
 The command to build Papy is the following once you are in the project root directory. 
 ```bash
-make build
+make rebuild
 ```
 ![Make build](docs/documentationImages/makeBuild.png "Make build")
 


### PR DESCRIPTION
Fixed the README.md build instruction typo; more info can be found in issue #20.