### PR TITLE
int vs size_t conversion and comparison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.10)
+project(papy)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O1 -Wall")
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -g -O1")
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF) 
+
+add_executable(papy
+    src/apiClient.cpp
+    src/cliHelper.cpp
+    src/main.cpp
+    src/mapping.cpp
+    src/matchBuilder.cpp
+    src/millisecondClock.cpp
+    src/myRandom.cpp
+    src/oceanBuilder.cpp
+    src/threadWorks.cpp
+)
+
+target_include_directories(papy PUBLIC
+    "${CMAKE_SOURCE_DIR}/src"
+    "${CMAKE_SOURCE_DIR}/src/dependencies"
+)
+
+find_package(ZLIB REQUIRED)
+find_package(OpenSSL REQUIRED)
+
+target_link_libraries(papy PRIVATE 
+    ZLIB::ZLIB
+    OpenSSL::Crypto
+    OpenSSL::SSL
+)
+
+

--- a/src/myRandom.cpp
+++ b/src/myRandom.cpp
@@ -89,6 +89,7 @@ bool myRandom::getRandomVectorFromJSON(std::vector<std::string>& participantData
     std::vector<std::string> keys;
     bool success = getKeysFromJsonObject(keys, jsonObject);
 
+    // unsure if 
     if (!success) {
         return false;
     }
@@ -97,8 +98,11 @@ bool myRandom::getRandomVectorFromJSON(std::vector<std::string>& participantData
     // std::mt19937 generate(randomDevice());
     std::uniform_int_distribution<> distrib(0, keys.size() - 1);
 
-    for (int i = 0; i < count; i++) {
-        int randomIndex = distrib(gen);
+    // comparison of size_t and int can lead to integer under/overflow from wrapping due to narrowing conversion of signdness 
+    for (size_t i = 0; i < count; i++) {
+        // size_t here will ensure that no signed conversion will happen
+        // while I would imagine that the number of keys would never exceed int_max it could happen and lead to undefined behaviour
+        size_t randomIndex = distrib(gen);
         // int index = randomIndex % keys.size();
         participantData.push_back(keys[randomIndex]);
         //participantData.push_back(keys.at(index));


### PR DESCRIPTION
The `int` type within the loop and as the type for `randomIndex` stuck out to me due to the consistent use of `size_t` within the class. I would recommend the change to size_t for consistency but also because signed vs unsigned comparison can lead to wrapping. As mentioned in the comments, while it would seem extremely unlikely that the number of keys would exceed `INT_MAX` it would lead to conversion semantics. This could potentially cause an unsigned value to become signed leading to a negative index or just UB. 

- feel free to ignore the cmakelist. It was just added so I could build the project. you can also include it as a very simple way to build with cmake.