### PR TITLE
Const correctness for strings and millisecondClock

### DIFF
--- a/src/apiClient.cpp
+++ b/src/apiClient.cpp
@@ -41,7 +41,7 @@ void apiClient::setPayload(const nlohmann::json& payload) {
     this->payload = payload;
 }
 
-std::string apiClient::sendGETRequest(std::string bearer, std::string authorization) {
+std::string apiClient::sendGETRequest(const std::string& bearer, const std::string& authorization) const {
     const std::string requestCombined = (endpoint.empty() ? "/" : endpoint) + (parameter.empty() ? "" : parameter);
 
     httplib::Result res;
@@ -72,7 +72,7 @@ std::string apiClient::sendGETRequest(std::string bearer, std::string authorizat
     return "Error: " + errorToString(res.error());
 }
 
-std::string apiClient::sendPOSTRequest(std::string bearer, std::string authorization) {
+std::string apiClient::sendPOSTRequest(const std::string& bearer, const std::string& authorization) const {
 
    httplib::Headers headers = {
         {"Content-Encoding", "gzip"}

--- a/src/apiClient.hpp
+++ b/src/apiClient.hpp
@@ -16,8 +16,8 @@ public:
     void setParameter(const std::string& parameter);
     void setPayload(const nlohmann::json& payload);
 
-    std::string sendGETRequest(std::string bearer, std::string authorization);
-    std::string sendPOSTRequest(std::string bearer, std::string authorization);
+    std::string sendGETRequest(const std::string& bearer, const std::string& authorization) const;
+    std::string sendPOSTRequest(const std::string& bearer, const std::string& authorization) const;
 
 private:
     std::unique_ptr<httplib::Client> client;
@@ -27,5 +27,5 @@ private:
     std::string parameter;
     nlohmann::json payload;
 
-    std::string errorToString(httplib::Error err);
+    static std::string errorToString(httplib::Error err);
 };

--- a/src/millisecondClock.cpp
+++ b/src/millisecondClock.cpp
@@ -9,14 +9,14 @@ void millisecondClock::start() {
 }
 
 // Get the elapsed time in milliseconds since the clock was started
-long long millisecondClock::perSecondCheck() {
+long long millisecondClock::perSecondCheck() const {
     auto now = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - currentStart);
     return duration.count();
 }
 
 // Get the elapsed time in milliseconds since the clock was started
-long long millisecondClock::elapsedMilliseconds() {
+long long millisecondClock::elapsedMilliseconds() const {
     auto now = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - initialStart);
     return duration.count();

--- a/src/millisecondClock.hpp
+++ b/src/millisecondClock.hpp
@@ -8,10 +8,10 @@ public:
     void start();
 
     // Get the elapsed time in milliseconds since the clock was started
-    long long perSecondCheck();
+    long long perSecondCheck() const;
 
     // Get the elapsed time in milliseconds since the clock was started
-    long long elapsedMilliseconds();
+    long long elapsedMilliseconds() const;
 
     // Reset the clock to the current time
     void resetClock();

--- a/src/threadWorks.cpp
+++ b/src/threadWorks.cpp
@@ -67,8 +67,7 @@ std::string threadWorks::gzip_compress(const std::string &data) {
     return compressed;
 }
 
-void threadWorks::sendRequest(apiClient& client, bool verbose, std::string payload, millisecondClock& clock, std::string bearer, std::string authorization) {
-    std::transform(payload.begin(), payload.end(), payload.begin(), ::tolower);
+void threadWorks::sendRequest(apiClient& client, bool verbose, const std::string& payload, const millisecondClock& clock, const std::string& bearer, const std::string& authorization) {
     std::string response;
 
     // TODO: Test out what it takes to implement reading the custom payload as a file path from anywhere rather than from just in the same directory as the binary executable file.
@@ -158,11 +157,13 @@ void threadWorks::sendRequest(apiClient& client, bool verbose, std::string paylo
 }
 
 // Orchestrates the sending of requests and main loop for program
-void threadWorks::runWorkerThread(const std::string& targetURL, const std::string& endpoint, bool verbose, int payloadCount, int rateLimit, int ramp, int spike, std::string payload, std::string parameter, std::string bearer, std::string authorization) {
+void threadWorks::runWorkerThread(const std::string& targetURL, const std::string& endpoint, bool verbose, int payloadCount, int rateLimit, int ramp, int spike, std::string payload, const std::string& parameter, const std::string& bearer, const std::string& authorization) {
     millisecondClock clock;
     apiClient client(targetURL);
     client.setEndpoint(endpoint);
     client.setParameter(parameter);
+
+    std::transform(payload.begin(), payload.end(), payload.begin(), ::tolower);
 
     clock.start();
     while (isProgramActive) {

--- a/src/threadWorks.hpp
+++ b/src/threadWorks.hpp
@@ -19,10 +19,10 @@ public:
     static void signalHandler(int signal);
 
     // Function to send requests and optionally log verbose output
-    static void sendRequest(apiClient& client, bool verbose, std::string payload, millisecondClock& clock, std::string bearer, std::string authorization);
+    static void sendRequest(apiClient& client, bool verbose, const std::string& payload, const millisecondClock& clock, const std::string& bearer, const std::string& authorization);
 
     // Worker thread function that sends requests based on the provided parameters
-    static void runWorkerThread(const std::string& targetURL, const std::string& endpoint, bool verbose, int payloadCount, int rateLimit, int ramp, int spike, std::string payload, std::string parameter, std::string bearer, std::string authorization);
+    static void runWorkerThread(const std::string& targetURL, const std::string& endpoint, bool verbose, int payloadCount, int rateLimit, int ramp, int spike, std::string payload, const std::string& parameter, const std::string& bearer, const std::string& authorization);
 
     static std::string gzip_compress(const std::string &data);
 };


### PR DESCRIPTION
Changed most strings to const string& for function parameters, same for millisecondClock, changed some functions in apiClient and millisecondClock to const as well. Changed one helper function in apiClient to static

Only change here that wasn't just in function signatures and whatnot was moving std::transform(payload ::toLower) which I moved out of sendRequest and into runWorkerThread so sendRequest can also just take a const string& and doesn't have to repeat work every request.