### PR TITLE
Introduce avg/s for console output

### DIFF
--- a/src/threadWorks.cpp
+++ b/src/threadWorks.cpp
@@ -147,12 +147,16 @@ void threadWorks::sendRequest(apiClient& client, bool verbose, std::string paylo
         last_update_time = now;
 
         // Print updated info on the same line
-        std::cout << "\rTotal Sent: " << totalPayloadsSent
+        long long ms = clock.elapsedMilliseconds();
+        int avg = (float)totalPayloadsSent / (float)ms * 1000.0f;
+
+        std::cout << "\033[2K\r" // clears entire line
+                  << "Total Sent: " << totalPayloadsSent
                   << " | Successful: " << totalPayloadsSuccessful
                   << " | Failed: " << (totalPayloadsSent - totalPayloadsSuccessful)
                   << " | Packets/s: " << packetsPerSecond
-                  << " | Elapsed Time: " << clock.elapsedMilliseconds()
-		  << "     "  // clear a few characters past the end
+                  << " | Average/s: " << avg
+                  << " | Elapsed Time: " << ms
                   << std::flush;
     }
 }


### PR DESCRIPTION
Added a simple Average/s for console output, made benchmarking a bit easier for myself :)

Also I added an ANSI escape code that clears the entire line to the output so we don't have to rely on some number of fixed spaces at the end to clear the line